### PR TITLE
Remove admin_media_prefix

### DIFF
--- a/quizblock/templates/admin/quizblock/answer/edit_inline/tabular.html
+++ b/quizblock/templates/admin/quizblock/answer/edit_inline/tabular.html
@@ -97,11 +97,11 @@
             if (typeof SelectFilter != "undefined"){
                 $(".selectfilter").each(function(index, value){
                   var namearr = value.name.split('-');
-                  SelectFilter.init(value.id, namearr[namearr.length-1], false, "{% admin_media_prefix %}");
+                  SelectFilter.init(value.id, namearr[namearr.length-1], false);
                 })
                 $(".selectfilterstacked").each(function(index, value){
                   var namearr = value.name.split('-');
-                  SelectFilter.init(value.id, namearr[namearr.length-1], true, "{% admin_media_prefix %}");
+                  SelectFilter.init(value.id, namearr[namearr.length-1], true);
                 })
             }
         }

--- a/quizblock/templates/admin/quizblock/question/change_form.html
+++ b/quizblock/templates/admin/quizblock/question/change_form.html
@@ -1,6 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_modify %}
 {% load markup %}
+{% load staticfiles %}
 
 {% block extrahead %}{{ block.super }}
 <script type="text/javascript" src="../../../jsi18n/"></script>
@@ -50,7 +51,7 @@
 
 {% endblock %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% admin_media_prefix %}css/forms.css" />{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %} />{% endblock %}
 
 {% block coltype %}{% if ordered_objects %}colMS{% else %}colM{% endif %}{% endblock %}
 

--- a/quizblock/templates/admin/quizblock/question/edit_inline/tabular.html
+++ b/quizblock/templates/admin/quizblock/question/edit_inline/tabular.html
@@ -105,11 +105,11 @@
             if (typeof SelectFilter != "undefined"){
                 $(".selectfilter").each(function(index, value){
                   var namearr = value.name.split('-');
-                  SelectFilter.init(value.id, namearr[namearr.length-1], false, "{% admin_media_prefix %}");
+                  SelectFilter.init(value.id, namearr[namearr.length-1], false);
                 })
                 $(".selectfilterstacked").each(function(index, value){
                   var namearr = value.name.split('-');
-                  SelectFilter.init(value.id, namearr[namearr.length-1], true, "{% admin_media_prefix %}");
+                  SelectFilter.init(value.id, namearr[namearr.length-1], true);
                 })
             }
         }

--- a/quizblock/templates/admin/quizblock/quiz/change_form.html
+++ b/quizblock/templates/admin/quizblock/quiz/change_form.html
@@ -1,5 +1,6 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_modify %}
+{% load staticfiles %}
 
 {% block extrahead %}{{ block.super }}
 <script type="text/javascript" src="../../../jsi18n/"></script>
@@ -84,7 +85,7 @@
 
 {% endblock %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% admin_media_prefix %}css/forms.css" />{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %} />{% endblock %}
 
 {% block coltype %}{% if ordered_objects %}colMS{% else %}colM{% endif %}{% endblock %}
 


### PR DESCRIPTION
I removed the deprecated `admin_media_prefix` since it was giving me errors. Using `static` works for me, but my changes to `SelectFilter.init` might break something. This is a start, though.
