### PR TITLE
Update jquery and fix jquery/require.js conflict

### DIFF
--- a/quizblock/templates/quizblock/edit_question.html
+++ b/quizblock/templates/quizblock/edit_question.html
@@ -19,16 +19,16 @@
 {% endblock %}
 
 {% block js %}
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>
+    {% include "quizblock/include_jquery.html" %}
 
     <script>
+        (function($) {
         var saveOrder = function() {
             var url = "{% url 'reorder-answer' question.id %}?";
             var worktodo = 0;
-            jQuery("#answers li").each(function(index,element) {
+            $("#answers li").each(function(index,element) {
                worktodo = 1;
-               var id = jQuery(element).attr('id').split("-")[1];
+               var id = $(element).attr('id').split("-")[1];
                url += "answer_" + index + "=" + id + ";";
             });
             if (worktodo == 1) {
@@ -38,8 +38,8 @@
             }
         };
         
-        jQuery(document).ready(function () {
-            jQuery("#answers").sortable({
+        $(document).ready(function () {
+            $("#answers").sortable({
                 containment : 'parent'
                 ,axis : 'y'
                 ,tolerance: 'pointer'
@@ -47,8 +47,9 @@
                 ,handle: '.draghandle'
                 ,stop: function (event,ui) { saveOrder();}
             });
-            jQuery("#answers").disableSelection();
+            $("#answers").disableSelection();
         });
+        })(quizblock.$);
     </script>
 
 

--- a/quizblock/templates/quizblock/edit_question.html
+++ b/quizblock/templates/quizblock/edit_question.html
@@ -2,7 +2,8 @@
 {% load bootstrap %}
 
 {% block css %}
-    <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.3/themes/base/jquery-ui.css" type="text/css" media="all" />
+<link rel="stylesheet"
+      href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/themes/smoothness/jquery-ui.css" />
 
     <style type="text/css">
         .draghandle {float: left;}
@@ -18,10 +19,10 @@
 {% endblock %}
 
 {% block js %}
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js" type="text/javascript" ></script>
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/jquery-ui.min.js" type="text/javascript"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>
 
-    <script type="text/javascript">
+    <script>
         var saveOrder = function() {
             var url = "{% url 'reorder-answer' question.id %}?";
             var worktodo = 0;

--- a/quizblock/templates/quizblock/include_jquery.html
+++ b/quizblock/templates/quizblock/include_jquery.html
@@ -1,0 +1,12 @@
+<!-- Prevent quizblock's jQuery and jQueryUI from interfering with the
+     main application's copy. -->
+<script>
+    var _quizblock_define_backup = window.define;
+    window.define = undefined;
+</script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>
+<script>
+    var quizblock = { $: jQuery.noConflict(true) };
+    window.define = _quizblock_define_backup;
+</script>

--- a/quizblock/templates/quizblock/quiz_detail.html
+++ b/quizblock/templates/quizblock/quiz_detail.html
@@ -2,7 +2,8 @@
 {% load bootstrap %}
 
 {% block css %}
-    <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.3/themes/base/jquery-ui.css" type="text/css" media="all" />
+<link rel="stylesheet"
+      href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/themes/smoothness/jquery-ui.css" />
 
     <style type="text/css">
         .draghandle {float: left;}
@@ -18,10 +19,10 @@
 
 {% block js %}
 
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js" type="text/javascript" ></script>
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/jquery-ui.min.js" type="text/javascript"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>
 
-    <script type="text/javascript">
+    <script>
         var saveOrder = function() {
             var url = "{% url 'reorder-questions' quiz.id %}?";
             var worktodo = 0;

--- a/quizblock/templates/quizblock/quiz_detail.html
+++ b/quizblock/templates/quizblock/quiz_detail.html
@@ -18,17 +18,16 @@
 {% endblock %}
 
 {% block js %}
-
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>
+    {% include "quizblock/include_jquery.html" %}
 
     <script>
+        (function($) {
         var saveOrder = function() {
             var url = "{% url 'reorder-questions' quiz.id %}?";
             var worktodo = 0;
-            jQuery("#questions li").each(function(index,element) {
+            $("#questions li").each(function(index,element) {
                worktodo = 1;
-               var id = jQuery(element).attr('id').split("-")[1];
+               var id = $(element).attr('id').split("-")[1];
                url += "question_" + index + "=" + id + ";";
             });
             if (worktodo == 1) {
@@ -38,8 +37,8 @@
             }
         };
         
-        jQuery(document).ready(function() {
-            jQuery("#questions").sortable({
+        $(document).ready(function() {
+            $("#questions").sortable({
               containment : 'parent'
               ,axis : 'y'
               ,tolerance: 'pointer'
@@ -47,9 +46,9 @@
               ,handle: '.draghandle'
               ,stop: function (event,ui) { saveOrder();}
             });
-            jQuery("#questions").disableSelection();
+            $("#questions").disableSelection();
           });
-
+        })(quizblock.$);
     </script>
 
 {% endblock %}


### PR DESCRIPTION
To fix bootstrap error: "Bootstrap's JavaScript requires jQuery version
1.9.1 or higher"

Also fixes a jQuery conflict with require.js that pagetree also had here: https://github.com/ccnmtl/django-pagetree/pull/14