### PR TITLE
Remove extra divider slash in breadcrumb. 

### DIFF
--- a/quizblock/templates/quizblock/quiz_detail.html
+++ b/quizblock/templates/quizblock/quiz_detail.html
@@ -47,10 +47,11 @@
 {% block content %}
 
 <ul class="breadcrumb">
-	<li><a href="{{quiz.pageblock.section.get_edit_url}}">{{quiz.pageblock.section.label}}</a>
-		<span class="divider">/</span>
-	</li>
-	<li>Edit Quiz</li>
+    <li>
+        <a href="{{quiz.pageblock.section.get_edit_url}}"
+           >{{quiz.pageblock.section.label}}</a>
+    </li>
+    <li>Edit Quiz</li>
 </ul>
 
 


### PR DESCRIPTION
These are added by bootstrap's CSS.

![2015-01-30-141913_305x79_scrot](https://cloud.githubusercontent.com/assets/59292/5981817/5de2c86e-a88b-11e4-9975-b96ce849fe16.png)
