### PR TITLE
Release version 1.0.3

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+1.0.3 (2015-02-09)
+==================
+
+* Allow CSS classes to be added to quiz answers
+
 1.0.2
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2010, Columbia Center For New Media Teaching And Learning (CCNMTL)
+# Copyright (c) 2010-2015, Columbia Center For New Media Teaching And Learning (CCNMTL)
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,7 +27,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="django-quizblock",
-    version="1.0.2",
+    version="1.0.3",
     author="Anders Pearson",
     author_email="anders@columbia.edu",
     url="https://github.com/ccnmtl/django-quizblock",


### PR DESCRIPTION
Release version 1.0.3 so I can use the `css_extra` attribute for worth2's protective behaviors quiz