### PR TITLE
Revert GenericRelation change (de94baf5df6c8ae6abe0ec918375a26ef3f59754)

### DIFF
--- a/quizblock/models.py
+++ b/quizblock/models.py
@@ -1,6 +1,10 @@
 from django import forms
 from django.contrib.auth.models import User
-from django.contrib.contenttypes.fields import GenericRelation
+try:
+    from django.contrib.contenttypes.fields import GenericRelation
+except ImportError:
+    # Old location for django 1.6
+    from django.contrib.contenttypes.generic import GenericRelation
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils.encoding import smart_str


### PR DESCRIPTION
Django 1.6 still needs this in the old location, so I reverted
and added a note. It's strange that the tests were still passing.