### PR TITLE
Add safe filter to some quiz answer labels

### DIFF
--- a/quizblock/templates/quizblock/multiple_choice.html
+++ b/quizblock/templates/quizblock/multiple_choice.html
@@ -9,7 +9,7 @@
                 <label>
                     <input name="question{{question.id}}"
                            value="{{answer.label}}" type="checkbox">
-                    <span class="caseanswerlabel">{{answer.label}}</span>
+                    <span class="caseanswerlabel">{{answer.label|safe}}</span>
                 </label>
             </li>
         {% else %}
@@ -25,7 +25,7 @@
                         value="{{answer.value}}" type="checkbox" disabled="disabled"
                         class="{% if answer.correct %}correct correctanswer{% else %}incorrect incorrectanswer{% endif %}"
                         {% ifanswerin response answer %}checked="checked"{% else %}{% endifanswerin %} />
-                        <span class="caseanswerlabel">{{answer.label}}</span>
+                        <span class="caseanswerlabel">{{answer.label|safe}}</span>
                     </label>
                     
                     <span class="caseanswerresult">
@@ -45,7 +45,7 @@
                     <label>
                         <input name="pageblock-{{block.pageblock.id}}-question{{question.id}}"
                                value="{{answer.value}}" type="checkbox">
-                        <span class="caseanswerlabel">{{answer.label}}</span>
+                        <span class="caseanswerlabel">{{answer.label|safe}}</span>
                     </label>
                 {% endif %}
             </li>

--- a/quizblock/templates/quizblock/multiple_choice_show_answer.html
+++ b/quizblock/templates/quizblock/multiple_choice_show_answer.html
@@ -12,7 +12,7 @@
                         {% else %}
                         <span class="incorrectanswer" %>
                             {% endif %}
-                            <span class="answer-inner">{{answer.label}}</span>
+                            <span class="answer-inner">{{answer.label|safe}}</span>
                         </span>
                 </li>
                 {% endfor %}

--- a/quizblock/templates/quizblock/single_choice.html
+++ b/quizblock/templates/quizblock/single_choice.html
@@ -7,7 +7,7 @@
                 <label>
                     <input name="question{{question.id}}" value="{{answer.label}}"
                            type="radio">
-                    {{answer.label}}
+                    {{answer.label|safe}}
                 </label>
             </li>
         {% else %}
@@ -20,7 +20,7 @@
                         {% ifequal response.value answer.value %}
                             class="yours {% if response.is_correct %}correct{% else %}incorrect{% endif %}"
                             checked="checked"
-                        {% endifequal %}/> <span class="caseanswerlabel">{{answer.label}}</span>
+                        {% endifequal %}/> <span class="caseanswerlabel">{{answer.label|safe}}</span>
                     </label>
                     
                     <span class="caseanswerresult">
@@ -38,7 +38,7 @@
                     <label>
                         <input name="pageblock-{{block.pageblock.id}}-question{{question.id}}"
                                value="{{answer.value}}" type="radio">
-                        <span class="caseanswerlabel">{{answer.label}}</span>
+                        <span class="caseanswerlabel">{{answer.label|safe}}</span>
                     </label>
                 {% endif %}
             </li>


### PR DESCRIPTION
If we want to add bootstrap glyphicons to the quiz labels,
we need to make the label as safe.

Fixes #45