### PR TITLE
Add Django >=1.7 migration for Quiz.show_submit_state.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+1.1.2
+==================
+* Add missing Quiz.show_submit_state migration
+
 1.1.1 (2015-05-04)
 ==================
 * Add Response.answer() method

--- a/quizblock/migrations/0005_re_add_show_submit_state.py
+++ b/quizblock/migrations/0005_re_add_show_submit_state.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations, utils
+
+
+class FailsafeAddField(migrations.AddField):
+    def database_forwards(self, app_label, schema_editor, from_state,
+                          to_state):
+        try:
+            super(FailsafeAddField, self).database_forwards(
+                app_label, schema_editor, from_state, to_state)
+        except utils.ProgrammingError:
+            # This column must have already been added by the
+            # initial migration, so don't do anything.
+            pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('quizblock', '0004_question_css_extra'),
+    ]
+
+    operations = [
+        FailsafeAddField('Quiz', 'show_submit_state',
+                         models.BooleanField(default=True))
+    ]


### PR DESCRIPTION
This is for apps that happened to be missing this column, because
the initial 1.7 migration was faked.

See: https://github.com/ccnmtl/wacep/pull/66