### PR TITLE
Detail Reports: Correct answer value > id mapping

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+1.1.4 (2015-10-14)
+==================
+* Fix detailed report bug: Map the answer id properly when there are multiple
+responses in the submission. Previously, the code was not filtering responses
+by the specified question. 
+
 1.1.3 (2015-07-09)
 ==================
 * Remove embedded form for rhetorical quizzes.

--- a/quizblock/models.py
+++ b/quizblock/models.py
@@ -486,7 +486,7 @@ class QuestionColumn(ReportColumnInterface):
             quiz=self.question.quiz, user=user).order_by("-submitted").first()
         if submission:
             value = ''
-            responses = submission.response_set
+            responses = submission.response_set.filter(question=self.question)
 
             if responses.count() > 0:
                 if self.question.is_single_choice():

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="django-quizblock",
-    version="1.1.3",
+    version="1.1.4",
     author="Anders Pearson",
     author_email="anders@columbia.edu",
     url="https://github.com/ccnmtl/django-quizblock",


### PR DESCRIPTION
Map the answer id properly when there are multiple
responses in the submission. Previously, the code was
not filtering responses by the specified question.